### PR TITLE
DHT22 support

### DIFF
--- a/geothunk/Presentation.cpp
+++ b/geothunk/Presentation.cpp
@@ -134,8 +134,11 @@ void Presentation::paintDisplay(long now) {
     humidityString = String("-");
     temperatureString = String("-");
   } else {
-    humidityString = String(airData->humidity);
-    temperatureString = String(airData->temperature);
+    char format_buffer[10];
+    snprintf(format_buffer, sizeof(format_buffer), "%0.0f", airData->humidity);
+    humidityString = String(format_buffer);
+    snprintf(format_buffer, sizeof(format_buffer), "%0.1f", airData->temperature);
+    temperatureString = String(format_buffer);
   }
   display->drawString(display->getWidth(), 34, pmValues);
   display->drawString(display->getWidth(), 44, humidityString + String("%h"));

--- a/geothunk/geothunk.h
+++ b/geothunk/geothunk.h
@@ -8,8 +8,8 @@ struct AirData {
   unsigned int pm10;
   enum AirDataStatus pmStatus;
 
-  byte temperature;
-  byte humidity;
+  float temperature;
+  float humidity;
 
   enum AirDataStatus tempHumidityStatus;
 };


### PR DESCRIPTION
This commit enables DHT22 sensor support with an optional define. DHT22 is a higher quality sensor than the DHT11, sensing a higher range of temperatures and humidities with 10th of a degree precision.

With DHT11, floats are still used, and the sensor simply reads and returns values with out any decimal precision.

Causes a slight breaking change to the /stats endpoint for clients that expected an integer. This could be made to format the value differently depending on the client.