### PR TITLE
Revert "Turn the LED off when we've connected"

### DIFF
--- a/geothunk/geothunk.ino
+++ b/geothunk/geothunk.ino
@@ -361,7 +361,6 @@ void setup() {
 
   presentation.paintConnectingWifi();
 
-  digitalWrite(LED_PIN, LOW);
   do {
     if ( digitalRead(TRIGGER_PIN) == LOW ) {
       WiFi.disconnect(true);
@@ -372,7 +371,6 @@ void setup() {
   } while (!wifiManager.autoConnect(ap_name));
 
   Serial.println("stored wifi connected");
-  digitalWrite(LED_PIN, HIGH);
 
   WiFi.setAutoConnect(true);
 
@@ -403,7 +401,7 @@ void setup() {
     configFile.close();
   }
 
-  presentation.paintConnectingMqtt(millis());
+  presentation.paintConnectingMqtt();
 
   client = new PubSubClient(*(new WiFiClient()));
   client->setServer(mqtt_server, strtoul(mqtt_port, NULL, 10));


### PR DESCRIPTION
Turns out.... the servo and the built-in LED are connected to the same GPIO pin. Turning off the LED causes a consistent amount of power (and heat) to be sent to the servo.

This reverts commit 2d08df3050450d5f88c8de28097dd8ddcd9e1c28.