### PR TITLE
Introduce and UniversalDHT to auto-detect DHT11 vs DHT22

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Libraries: sketch->include library->manage libraries
 * WiFiManager (0.14.x)
 * ArduinoJson (5.x.x)
 * PubSubClient (2.x.x)
-* SimpleDHT  (1.x.x)
 * "ESP8266 and ESP32 Oled Driver for SSD1306 display" (4.x.x)
 * Esp8266TrueRandom (wget https://github.com/marvinroger/ESP8266TrueRandom/archive/master.zip; sketch->include library->Add .zip Library)
 

--- a/geothunk/UniversalDHT.cpp
+++ b/geothunk/UniversalDHT.cpp
@@ -141,7 +141,7 @@ DHTResponse UniversalDHT::sample(RawReading *reading) {
   //    1. PULL LOW 80us
   //    2. PULL HIGH 80us
   waitWhileValue(pin, LOW);
-  int t = advance(lf, nf);;
+  int t = advance(lf, nf);
   if (t < 30) {                    // specs [2]: 80us
     ret.time = t;
     ret.error = errStartLow;
@@ -163,7 +163,7 @@ DHTResponse UniversalDHT::sample(RawReading *reading) {
   //    2. PULL HIGH:
   //         - 26-28us, bit(0)
   //         - 70us, bit(1)
-  for (byte byte_idx = 0; byte_idx < 5; byte_idx ++) {
+  for (byte byte_idx = 0; byte_idx < sizeof(RawReading); byte_idx ++) {
     ptr = (byte*)reading + byte_idx;
     *ptr = 0;
     for (signed char bit_idx = 7; bit_idx >= 0; bit_idx --) {

--- a/geothunk/UniversalDHT.cpp
+++ b/geothunk/UniversalDHT.cpp
@@ -1,0 +1,201 @@
+/*
+  Universal auto-detecting DHT11 or DHT22 sensor.
+
+  Copyright (c) 2019 Tim Harper
+
+  https://github.com/timcharper
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * This module is a rewrite of SimpleDHT: https://github.com/winlinvip/SimpleDHT
+ *
+ * SimpleDHT is Copyright (c) 2016-2017 winlin, and is also licensed MIT
+ */
+
+#include "UniversalDHT.h"
+
+DHTResponse parseDHT(short* ptemperature, short* phumidity, RawReading* reading) {
+  DHTResponse ret = {success, 0};
+
+  byte expect = reading->humidity16 + reading->humidity8 + reading->temperature16 + reading->temperature8;
+  if (reading->checksum != expect) {
+    ret.error = errDataChecksum;
+    return ret;
+  }
+
+  *ptemperature = reading->temperature16 << 8 | reading->temperature8;
+  *phumidity = reading->humidity16 << 8 | reading->humidity8;
+  return ret;
+}
+
+UniversalDHT::UniversalDHT(int pin) {
+  this->pin = pin;
+}
+
+bool waitWhileValue(int pin, byte value) {
+  unsigned long time_start = micros();
+  long time = 0;
+
+  while (digitalRead(pin) == value) {
+    delayMicroseconds(6);
+    time = micros() - time_start;
+    if ((time < 0) || (time > VALUE_TIMEOUT)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+DHTResponse parseDHT11(short rawTemperature, short rawHumidity, float* ptemperature, float* phumidity) {
+  DHTResponse ret = {success, 0};
+
+  if (ptemperature) {
+    *ptemperature = (float)(rawTemperature>>8);
+  }
+  if (phumidity) {
+    *phumidity = (float)(rawHumidity>>8);
+  }
+  return ret;
+}
+
+DHTResponse parseDHT22(short rawTemperature, short rawHumidity, float* ptemperature, float* phumidity) {
+  DHTResponse ret = {success, 0};
+
+  if (ptemperature) {
+    *ptemperature = (float)((rawTemperature & 0x8000 ? -1 : 1) * (rawTemperature & 0x7FFF)) / 10.0;
+  }
+  if (phumidity) {
+    *phumidity = (float)rawHumidity / 10.0;
+  }
+
+  return ret;
+}
+
+DHTResponse UniversalDHT::read(float* ptemperature, float* phumidity) {
+  RawReading reading;
+  DHTResponse ret = sample(&reading);
+  if (ret.error) return ret;
+
+  short rawHumidity;
+  short rawTemperature;
+
+  ret = parseDHT(&rawHumidity, &rawTemperature, &reading);
+  if (ret.error) return ret;
+
+  /**
+   * DHT11 min humidity sensitivity is 20 and is reported as 20, 0
+   * DHT22 max humidity is 100 and is reported as 3, 232
+   * A value of 4, x or greater can be safely assumed as a DHT11 reading
+   */
+  if (reading.humidity16 > 4)
+    return parseDHT11(rawHumidity, rawTemperature, ptemperature, phumidity);
+  else
+    return parseDHT22(rawHumidity, rawTemperature, ptemperature, phumidity);
+}
+
+
+inline int advance(long &last_frame, long &next_frame) {
+  last_frame = next_frame;
+  next_frame = micros();
+  return next_frame - last_frame;
+}
+
+DHTResponse UniversalDHT::sample(RawReading *reading) {
+  long lf, nf = 0;
+  DHTResponse ret = {success, 0};
+
+  // https://www.sparkfun.com/datasheets/Sensors/Temperature/DHT22.pdf
+  pinMode(pin, OUTPUT);
+  digitalWrite(pin, LOW);            // Step 1: send start signal
+  delay(20);                         // DHT11: at least 18ms; DHT22: at least 1ms
+
+  // Pull high and set to input, before wait 40us.
+  digitalWrite(pin, HIGH);           // 2.
+  delayMicroseconds(25);             // specs [2]: 20-40us
+
+  advance(lf, nf);
+
+  // pin_mode change can take variable amounts of time to return; starting our timer measurement before calling pinMode
+  // is paramount for reliable timings
+  pinMode(pin, INPUT);
+
+  // DHT11 starting:
+  //    1. PULL LOW 80us
+  //    2. PULL HIGH 80us
+  waitWhileValue(pin, LOW);
+  int t = advance(lf, nf);;
+  if (t < 30) {                    // specs [2]: 80us
+    ret.time = t;
+    ret.error = errStartLow;
+    return ret;
+  }
+
+  waitWhileValue(pin, HIGH);             // 2.
+  t = advance(lf, nf);
+  if (t < 50) {                    // specs [2]: 80us
+    ret.time = t;
+    ret.error = errStartHigh;
+    return ret;
+  }
+
+
+  byte *ptr = (byte *)reading;
+  // DHTxx data transmission:
+  //    1. 1bit start, PULL LOW 50us
+  //    2. PULL HIGH:
+  //         - 26-28us, bit(0)
+  //         - 70us, bit(1)
+  for (byte byte_idx = 0; byte_idx < 5; byte_idx ++) {
+    ptr = (byte*)reading + byte_idx;
+    *ptr = 0;
+    for (signed char bit_idx = 7; bit_idx >= 0; bit_idx --) {
+      waitWhileValue(pin, LOW);          // 1.
+      t = advance(lf, nf);
+      if (t < 24) {                    // specs says: 50us
+        ret.time = t;
+        ret.error = errDataLow;
+        return ret;
+      }
+
+      // read a bit
+      waitWhileValue(pin, HIGH);              // 2.
+      t = advance(lf, nf);
+      if (t < 11) {                     // specs say: 26-28us
+        ret.time = t;
+        ret.error = errDataRead;
+        return ret;
+      }
+
+      *ptr = *ptr | ((t > 40 ? 1 : 0) << bit_idx);     // specs: 26-28us -> 0, 70us -> 1
+    }
+  }
+
+  // DHT11 EOF:
+  //    1. PULL LOW 50us.
+  waitWhileValue(pin, LOW);                     // 1.
+  t = advance(lf, nf);
+  if (t < 24) {                           // specs say: 50us
+    ret.time = t;
+    ret.error = errDataEOF;
+  }
+
+  return ret;
+}

--- a/geothunk/UniversalDHT.h
+++ b/geothunk/UniversalDHT.h
@@ -1,0 +1,67 @@
+/*
+  Universal auto-detecting DHT11 or DHT22 sensor.
+
+  Copyright (c) 2019 Tim Harper
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#ifndef __UniversalDHT_H
+#define __UniversalDHT_H
+
+#include <Arduino.h>
+
+#define VALUE_TIMEOUT 10000 // 10ms
+
+enum UniversalDHTResult: unsigned char
+{
+  success = 0, // Success.
+    errStartLow = 1, // Low signal came faster than expected
+    errStartHigh = 2, //
+    errDataLow = 3, //
+    errDataRead = 4, //
+    errDataEOF = 5, //
+    errDataChecksum = 6 // Checksum for read data didn't match
+    };
+
+
+
+struct DHTResponse {
+  UniversalDHTResult error;
+  unsigned char time;
+};
+
+struct RawReading {
+  byte humidity16;
+  byte humidity8;
+  byte temperature16;
+  byte temperature8;
+  byte checksum;
+};
+
+class UniversalDHT {
+ private:
+  int pin;
+  DHTResponse sample(RawReading *reading);
+ public:
+  UniversalDHT(int pin);
+  DHTResponse read(float* temperature, float* humidity);
+};
+
+#endif

--- a/geothunk/UniversalDHT.h
+++ b/geothunk/UniversalDHT.h
@@ -47,6 +47,9 @@ struct DHTResponse {
   unsigned char time;
 };
 
+/**
+ * Struct which encodes the protocol for the data sent by the DHT sensor
+ */
 struct RawReading {
   byte humidity16;
   byte humidity8;
@@ -54,6 +57,7 @@ struct RawReading {
   byte temperature8;
   byte checksum;
 };
+
 
 class UniversalDHT {
  private:

--- a/geothunk/geothunk.ino
+++ b/geothunk/geothunk.ino
@@ -26,21 +26,17 @@
 #include <ESP8266httpUpdate.h>
 #include <WiFiClientSecure.h>
 #include <time.h>
-#include <SimpleDHT.h>
 #include <Servo.h>
 #include "PmsSensorReader.h"
 #include "Presentation.h"
+#include "UniversalDHT.h"
 
 int pinDHT = D3;
-#ifdef DHT22
-SimpleDHT22 dht(pinDHT);
-#else
-SimpleDHT11 dht(pinDHT);
-#endif
+UniversalDHT dht(pinDHT);
 
 // use arduino library manager to get libraries
 // sketch->include library->manage libraries
-// WiFiManager, ArduinoJson, PubSubClient, ArduinoOTA, SimpleDHT, "ESP8266 and ESP32 Oled Driver for SSD1306 display"
+// WiFiManager, ArduinoJson, PubSubClient, ArduinoOTA, "ESP8266 and ESP32 Oled Driver for SSD1306 display"
 // wget https://github.com/marvinroger/ESP8266TrueRandom/archive/master.zip
 // sketch->include library->Add .zip Library
 // or... manually...
@@ -234,13 +230,11 @@ void handleGPS() {
 }
 
 void measureDHT() {
-  int err = SimpleDHTErrSuccess;
-
   float temperature, humidity = 0;
-  err = dht.read2(&temperature, &humidity, NULL);
+  DHTResponse response = dht.read(&temperature, &humidity);
 #ifdef DEBUG
-  if(err != SimpleDHTErrSuccess) {
-    Serial.printf("Read DHTxx failed t=%d err=%02x\n", err >> 8, err & 0xff);
+  if(response.error) {
+    Serial.printf("Read DHTxx failed t=%d err=%d\n", response.time, response.error);
   } else {
     Serial.print("Sample OK: ");
     Serial.print((float)temperature); Serial.print(" *C, ");
@@ -248,7 +242,7 @@ void measureDHT() {
     Serial.println();
   }
 #endif
-  if (err == SimpleDHTErrSuccess) {
+  if (!response.error) {
     lastDHTReading = millis();
     airData.humidity = humidity;
     airData.temperature = temperature;


### PR DESCRIPTION
UniversalDHT has improved timing detection; switching pinMode can introduce a variable delay. Starting our timer before switching pinMode vastly improved the determistic properties of the sample function.